### PR TITLE
Add threaded ChatGPT conversations with memory

### DIFF
--- a/CyberChan/Services/AiService.cs
+++ b/CyberChan/Services/AiService.cs
@@ -1,23 +1,70 @@
 ﻿using CyberChan.Extensions;
+using DSharpPlus;
+using DSharpPlus.Commands;
 using DSharpPlus.Entities;
 using Betalgo.Ranul.OpenAI;
 using Betalgo.Ranul.OpenAI.Managers;
 using Betalgo.Ranul.OpenAI.ObjectModels;
-using GptModels = Betalgo.Ranul.OpenAI.ObjectModels.Models;
 using Betalgo.Ranul.OpenAI.ObjectModels.RequestModels;
+using GptModels = Betalgo.Ranul.OpenAI.ObjectModels.Models;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
-using DSharpPlus.Commands;
-using System.IO;
 
 namespace CyberChan.Services
 {
     internal class AiService(OpenAIService openAiService)
     {
+        private readonly ConcurrentDictionary<ulong, ConversationState> _threadConversations = new();
+
+        private sealed class ConversationState
+        {
+            public ConversationState()
+            {
+                Messages = new List<ChatMessage>();
+                Lock = new SemaphoreSlim(1, 1);
+            }
+
+            public List<ChatMessage> Messages { get; }
+            public string Seed { get; set; } = string.Empty;
+            public string Model { get; set; } = string.Empty;
+            public int TokenLimit { get; set; }
+            public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
+            public SemaphoreSlim Lock { get; }
+        }
+
+        public enum ConversationResultStatus
+        {
+            Ignored,
+            Success,
+            ModerationFailed
+        }
+
+        public sealed class ConversationResult
+        {
+            private ConversationResult(ConversationResultStatus status, string? response = null)
+            {
+                Status = status;
+                Response = response;
+            }
+
+            public ConversationResultStatus Status { get; }
+
+            public string? Response { get; }
+
+            public static ConversationResult Ignored { get; } = new(ConversationResultStatus.Ignored);
+
+            public static ConversationResult ModerationFailed { get; } = new(ConversationResultStatus.ModerationFailed);
+
+            public static ConversationResult Success(string response) => new(ConversationResultStatus.Success, response);
+        }
+
         private List<ChatMessage> ChatSeed(string query, string seed)
         {
             var promptSeed = new List<ChatMessage>();
@@ -311,67 +358,72 @@ namespace CyberChan.Services
         }
         public async Task<string> GPT35Prompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, seed, GptModels.Gpt_3_5_Turbo_16k, 15360);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, GptModels.Gpt_3_5_Turbo_16k, 15360);
             return searchResult;
         }
 
         public async Task<string> GPT4Prompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, seed, GptModels.Gpt_4, 7168);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, GptModels.Gpt_4, 7168);
             return searchResult;
         }
 
         public async Task<string> GPT4PreviewPrompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, seed, GptModels.Gpt_4_turbo_preview, 3072);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, GptModels.Gpt_4_turbo_preview, 3072);
             return searchResult;
         }
 
         public async Task<string> GPT4OmniPrompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, seed, GptModels.Gpt_4o, 3072);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, GptModels.Gpt_4o, 3072);
             return searchResult;
         }
 
         public async Task<string> GPTO1Prompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, "o1", GptModels.O1_mini, 3072);
+            var promptSeed = ChatSeed(query, "o1");
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, GptModels.O1_mini, 3072);
             return searchResult;
         }
 
         public async Task<string> O4MiniPrompt(string query, string user, string seed)
         {
-            // o4-mini might be a newer model, using o1-mini as fallback or it could be "gpt-4o-mini"
-            var searchResult = await ChatGPTPromptTask(query, user, seed, "gpt-4o-mini", 3072);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, "gpt-4o-mini", 3072);
             return searchResult;
         }
 
         public async Task<string> GPT41NanoPrompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, seed, "gpt-4.1-nano", 3072);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, "gpt-4.1-nano", 3072);
             return searchResult;
         }
 
         public async Task<string> GPT41Prompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, seed, "gpt-4.1", 3072);
+            var promptSeed = ChatSeed(query, seed);
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, "gpt-4.1", 3072);
             return searchResult;
         }
 
         public async Task<string> O3Prompt(string query, string user, string seed)
         {
-            var searchResult = await ChatGPTPromptTask(query, user, "o1", "o3", 3072);
+            var promptSeed = ChatSeed(query, "o1");
+            var searchResult = await ChatGPTPromptTask(promptSeed, user, "o3", 3072);
             return searchResult;
         }
 
-        private async Task<string> ChatGPTPromptTask(string query, string user, string seed, string model, int tokens)
+        private async Task<string> ChatGPTPromptTask(List<ChatMessage> messages, string user, string model, int tokens)
         {
-
-            var promptSeed = ChatSeed(query, seed);
-
             var completionResult = openAiService.ChatCompletion.CreateCompletionAsStream(new ChatCompletionCreateRequest()
             {
-                Messages = promptSeed,
+                Messages = messages,
                 //MaxTokens = tokens,
                 Model = model,
                 User = user
@@ -394,6 +446,109 @@ namespace CyberChan.Services
                 }
             }
             return searchResult;
+        }
+
+        private static string FormatUserMessage(string username, string content)
+        {
+            return string.IsNullOrWhiteSpace(username) ? content : $"{username}: {content}";
+        }
+
+        private static List<string> PrepareResponseChunks(string response)
+        {
+            if (string.IsNullOrWhiteSpace(response))
+            {
+                return new List<string> { "_I'm sorry, I couldn't generate a response._" };
+            }
+
+            return response.SplitBy(1900).ToList();
+        }
+
+        private static string SanitizeThreadText(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return "chat";
+            }
+
+            var cleaned = new string(text.Where(c => !char.IsControl(c)).ToArray())
+                .Replace('\n', ' ')
+                .Replace('\r', ' ')
+                .Trim();
+
+            if (cleaned.Length > 40)
+            {
+                cleaned = cleaned[..40];
+            }
+
+            return string.IsNullOrWhiteSpace(cleaned) ? "chat" : cleaned;
+        }
+
+        private static string BuildThreadName(CommandContext ctx, string query)
+        {
+            var sanitized = SanitizeThreadText(query);
+            var baseName = $"{ctx.User.Username}-{sanitized}".Trim('-', ' ');
+
+            if (string.IsNullOrWhiteSpace(baseName))
+            {
+                baseName = $"{ctx.User.Username}-chat";
+            }
+
+            if (baseName.Length > 90)
+            {
+                baseName = baseName[..90];
+            }
+
+            return baseName;
+        }
+
+        private (string Model, int TokenLimit, string? SeedOverride) ResolveModel(Func<string, string, string, Task<string>> modelDelegate)
+        {
+            if (modelDelegate == GPT35Prompt)
+            {
+                return (GptModels.Gpt_3_5_Turbo_16k, 15360, null);
+            }
+
+            if (modelDelegate == GPT4Prompt)
+            {
+                return (GptModels.Gpt_4, 7168, null);
+            }
+
+            if (modelDelegate == GPT4PreviewPrompt)
+            {
+                return (GptModels.Gpt_4_turbo_preview, 3072, null);
+            }
+
+            if (modelDelegate == GPT4OmniPrompt)
+            {
+                return (GptModels.Gpt_4o, 3072, null);
+            }
+
+            if (modelDelegate == GPTO1Prompt)
+            {
+                return (GptModels.O1_mini, 3072, "o1");
+            }
+
+            if (modelDelegate == O4MiniPrompt)
+            {
+                return ("gpt-4o-mini", 3072, null);
+            }
+
+            if (modelDelegate == GPT41NanoPrompt)
+            {
+                return ("gpt-4.1-nano", 3072, null);
+            }
+
+            if (modelDelegate == GPT41Prompt)
+            {
+                return ("gpt-4.1", 3072, null);
+            }
+
+            if (modelDelegate == O3Prompt)
+            {
+                return ("o3", 3072, "o1");
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(modelDelegate), "Unknown model delegate provided.");
         }
 
         public async Task<string> Moderation(string query)
@@ -420,12 +575,55 @@ namespace CyberChan.Services
             return searchResult;
         }
 
+        public bool IsThreadConversation(ulong threadId) => _threadConversations.ContainsKey(threadId);
+
+        public void ClearConversation(ulong threadId)
+        {
+            if (_threadConversations.TryRemove(threadId, out var state))
+            {
+                state.Lock.Dispose();
+            }
+        }
+
+        public async Task<ConversationResult> ContinueThreadConversationAsync(ulong threadId, string username, string userMention, string messageContent)
+        {
+            if (!_threadConversations.TryGetValue(threadId, out var state))
+            {
+                return ConversationResult.Ignored;
+            }
+
+            await state.Lock.WaitAsync();
+            try
+            {
+                if (await Moderation(messageContent) != "Pass")
+                {
+                    return ConversationResult.ModerationFailed;
+                }
+
+                state.Messages.Add(new ChatMessage(StaticValues.ChatMessageRoles.User, FormatUserMessage(username, messageContent)));
+                var response = await ChatGPTPromptTask(state.Messages, userMention, state.Model, state.TokenLimit);
+
+                if (!string.IsNullOrWhiteSpace(response))
+                {
+                    state.Messages.Add(new ChatMessage(StaticValues.ChatMessageRoles.Assistant, response));
+                }
+
+                state.LastUpdated = DateTime.UtcNow;
+
+                return ConversationResult.Success(response);
+            }
+            finally
+            {
+                state.Lock.Release();
+            }
+        }
+
         public async Task GPTPromptCommon(Func<string, string, string, Task<string>> modelDelegate, CommandContext ctx, string query)
         {
             await ctx.DeferResponseAsync();
             await ctx.Channel.TriggerTypingAsync();
 
-            var seed = "";
+            var seed = string.Empty;
 
             if (query.StartsWith("<") && query.Contains(">"))
             {
@@ -433,22 +631,134 @@ namespace CyberChan.Services
                 query = query.Split("> ")[1].Trim();
             }
 
-            if (await Moderation(query) == "Pass")
+            if (await Moderation(query) != "Pass")
             {
-                var embed = new DiscordEmbedBuilder();
-                embed.AddField("Question:", query);
-                foreach (var chunk in (await modelDelegate(query, ctx.User.Mention, seed)).SplitBy(1024))
-                {
-                    embed.AddField("Cyber-chan Says:", chunk);
-                }
+                await ctx.RespondAsync("Query failed to pass OpenAI content moderation");
+                return;
+            }
 
-                await ctx.RespondAsync(embed);
+            var modelInfo = ResolveModel(modelDelegate);
+
+            if (!string.IsNullOrWhiteSpace(modelInfo.SeedOverride))
+            {
+                seed = modelInfo.SeedOverride;
+            }
+
+            DiscordThreadChannel threadChannel;
+            bool createdThread = false;
+
+            if (ctx.Channel is DiscordThreadChannel existingThread)
+            {
+                threadChannel = existingThread;
             }
             else
             {
-                await ctx.RespondAsync("Query failed to pass OpenAI content moderation");
+                var threadName = BuildThreadName(ctx, query);
+                threadChannel = await ctx.Message.CreateThreadAsync(threadName, AutoArchiveDuration.OneDay);
+                createdThread = true;
             }
 
+            var state = _threadConversations.GetOrAdd(threadChannel.Id, _ => new ConversationState());
+            string response;
+
+            await state.Lock.WaitAsync();
+            try
+            {
+                if (createdThread || !string.Equals(state.Model, modelInfo.Model, StringComparison.OrdinalIgnoreCase))
+                {
+                    state.Messages.Clear();
+                }
+
+                if (!string.IsNullOrWhiteSpace(seed))
+                {
+                    if (state.Messages.Count > 0 && !string.Equals(state.Seed, seed, StringComparison.OrdinalIgnoreCase))
+                    {
+                        state.Messages.Clear();
+                    }
+
+                    state.Seed = seed;
+                }
+                else if (string.IsNullOrWhiteSpace(state.Seed))
+                {
+                    state.Seed = string.Empty;
+                }
+
+                var isFreshConversation = state.Messages.Count == 0;
+
+                if (isFreshConversation)
+                {
+                    var promptSeed = ChatSeed(query, state.Seed);
+                    if (promptSeed.Count > 0)
+                    {
+                        var lastIndex = promptSeed.Count - 1;
+                        var lastMessage = promptSeed[lastIndex];
+                        if (lastMessage.Role == StaticValues.ChatMessageRoles.User)
+                        {
+                            promptSeed[lastIndex] = new ChatMessage(lastMessage.Role, FormatUserMessage(ctx.User.Username, query));
+                        }
+                    }
+
+                    state.Messages.AddRange(promptSeed);
+                }
+                else
+                {
+                    state.Messages.Add(new ChatMessage(StaticValues.ChatMessageRoles.User, FormatUserMessage(ctx.User.Username, query)));
+                }
+
+                state.Model = modelInfo.Model;
+                state.TokenLimit = modelInfo.TokenLimit;
+
+                response = await ChatGPTPromptTask(state.Messages, ctx.User.Mention, state.Model, state.TokenLimit);
+
+                if (!string.IsNullOrWhiteSpace(response))
+                {
+                    state.Messages.Add(new ChatMessage(StaticValues.ChatMessageRoles.Assistant, response));
+                }
+
+                state.LastUpdated = DateTime.UtcNow;
+            }
+            finally
+            {
+                state.Lock.Release();
+            }
+
+            var responseChunks = PrepareResponseChunks(response);
+
+            if (createdThread)
+            {
+                await ctx.RespondAsync($"🧵 Started a chat thread: {threadChannel.Mention}. I'll reply there!");
+                await threadChannel.TriggerTypingAsync();
+
+                if (!string.IsNullOrWhiteSpace(query))
+                {
+                    await threadChannel.SendMessageAsync($"**{ctx.User.Username}** asked:\n{query}");
+                }
+
+                var firstChunk = true;
+                foreach (var chunk in responseChunks)
+                {
+                    var content = firstChunk ? $"**Cyber-chan:**\n{chunk}" : chunk;
+                    await threadChannel.SendMessageAsync(content);
+                    firstChunk = false;
+                }
+            }
+            else
+            {
+                await threadChannel.TriggerTypingAsync();
+                var firstChunk = true;
+                foreach (var chunk in responseChunks)
+                {
+                    if (firstChunk)
+                    {
+                        await ctx.RespondAsync($"**Cyber-chan:**\n{chunk}");
+                        firstChunk = false;
+                    }
+                    else
+                    {
+                        await threadChannel.SendMessageAsync(chunk);
+                    }
+                }
+            }
         }
     }
 }

--- a/CyberChan/Services/DiscordService.cs
+++ b/CyberChan/Services/DiscordService.cs
@@ -1,11 +1,14 @@
-﻿using DSharpPlus;
+﻿using CyberChan.Extensions;
+using DSharpPlus;
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.Processors.TextCommands;
 using DSharpPlus.Commands.Processors.TextCommands.Parsing;
 using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
 using DSharpPlus.Interactivity;
 using DSharpPlus.Interactivity.Enums;
 using DSharpPlus.Interactivity.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Threading;
@@ -15,9 +18,14 @@ namespace CyberChan.Services
 {
     internal class DiscordService(IHostApplicationLifetime applicationLifetime, IServiceProvider serviceProvider, DiscordClient discordClient) : IHostedService
     {
+        private readonly AiService aiService = serviceProvider.GetRequiredService<AiService>();
+
         public async Task StartAsync(CancellationToken token)
         {
             discordClient.MessageCreated += Program.AutoReplyToSean;
+            discordClient.MessageCreated += HandleThreadConversationAsync;
+            discordClient.ThreadDeleted += HandleThreadDeletedAsync;
+            discordClient.ThreadUpdated += HandleThreadUpdatedAsync;
 
             // Add interactivity
             discordClient.UseInteractivity(new InteractivityConfiguration()
@@ -56,8 +64,87 @@ namespace CyberChan.Services
 
         public async Task StopAsync(CancellationToken token)
         {
+            discordClient.MessageCreated -= Program.AutoReplyToSean;
+            discordClient.MessageCreated -= HandleThreadConversationAsync;
+            discordClient.ThreadDeleted -= HandleThreadDeletedAsync;
+            discordClient.ThreadUpdated -= HandleThreadUpdatedAsync;
             await discordClient.DisconnectAsync();
             // More cleanup possibly here
+        }
+
+        private async Task HandleThreadConversationAsync(DiscordClient sender, MessageCreateEventArgs e)
+        {
+            if (e.Author.IsBot)
+            {
+                return;
+            }
+
+            if (e.Channel is not DiscordThreadChannel threadChannel)
+            {
+                return;
+            }
+
+            if (!aiService.IsThreadConversation(threadChannel.Id))
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(e.Message.Content))
+            {
+                return;
+            }
+
+            if (e.Message.Content.StartsWith("!", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            await threadChannel.TriggerTypingAsync();
+
+            var result = await aiService.ContinueThreadConversationAsync(threadChannel.Id, e.Author.Username, e.Author.Mention, e.Message.Content);
+
+            switch (result.Status)
+            {
+                case AiService.ConversationResultStatus.Ignored:
+                    return;
+                case AiService.ConversationResultStatus.ModerationFailed:
+                    await threadChannel.SendMessageAsync("⚠️ Sorry, that message didn't pass moderation.");
+                    return;
+                case AiService.ConversationResultStatus.Success:
+                    var responseText = string.IsNullOrWhiteSpace(result.Response)
+                        ? "_I'm sorry, I couldn't generate a response._"
+                        : result.Response;
+
+                    var firstChunk = true;
+                    foreach (var chunk in responseText.SplitBy(1900))
+                    {
+                        var content = firstChunk ? $"**Cyber-chan:**\n{chunk}" : chunk;
+                        await threadChannel.SendMessageAsync(content);
+                        firstChunk = false;
+                    }
+
+                    return;
+            }
+        }
+
+        private Task HandleThreadDeletedAsync(DiscordClient sender, ThreadDeleteEventArgs e)
+        {
+            if (e.Thread != null)
+            {
+                aiService.ClearConversation(e.Thread.Id);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task HandleThreadUpdatedAsync(DiscordClient sender, ThreadUpdateEventArgs e)
+        {
+            if (e.ThreadAfter != null && e.ThreadAfter.IsArchived)
+            {
+                aiService.ClearConversation(e.ThreadAfter.Id);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Summary
- start ChatGPT conversations in dedicated Discord threads and reuse the thread for follow-up prompts
- persist per-thread chat history with concurrency controls so replies retain context throughout the thread lifetime
- auto-reply to thread messages, clean up memory when threads close, and acknowledge moderation failures to users

## Testing
- `dotnet build` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a20be1fc832ab37419654c54d6b2